### PR TITLE
fest: add generic support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,9 @@ before_script: greenkeeper-lockfile-update
 
 script:
   - npm run verify
-  - npm install coveralls && npm run coveralls
 
 after_script: greenkeeper-lockfile-upload
 
 after_success:
+  - npm install coveralls && npm run coveralls
   - npm run semantic-release

--- a/src/Satisfier.exec.spec.ts
+++ b/src/Satisfier.exec.spec.ts
@@ -15,6 +15,17 @@ function assertExec(t, entry, path, expected, actual) {
   t.deepEqual(entry.actual, actual)
 }
 
+test('primitive types', t => {
+  t.is(new Satisfier(1).exec(1), null)
+  t.is(new Satisfier(true).exec(true), null)
+  t.is(new Satisfier('a').exec('a'), null)
+})
+
+test('can use generic to specify the data structure', t => {
+  t.is(new Satisfier<number>(1).exec(1), null)
+  t.is(new Satisfier<{ a: number }>({a: /1/ }).exec({a: 1}), null)
+})
+
 test('empty expecter passes everything', t => {
   t.is(new Satisfier({}).exec({}), null)
   t.is(new Satisfier({}).exec({ a: 1 }), null)

--- a/src/Satisfier.ts
+++ b/src/Satisfier.ts
@@ -1,5 +1,5 @@
+import { createSatisfier } from './createSatisfier'
 import { Expecter, Struct, SatisfierExec } from './interfaces'
-import { createSatisfier } from './createSatisfier';
 
 export class Satisfier<T extends Struct> {
   private satisfier

--- a/src/Satisfier.ts
+++ b/src/Satisfier.ts
@@ -1,56 +1,14 @@
-import { formatFunction } from 'function-formatter'
+import { Expecter, Struct, SatisfierExec } from './interfaces'
+import { createSatisfier } from './createSatisfier';
 
-import { Expecter, Struct } from './interfaces'
-
-export interface SatisfierExec {
-  path: string[],
-  expected: any,
-  actual: any
-}
-
-/**
- * creates a satisfier
- * @param expected All properties can be a value which will be compared to the same property in `actual`, RegExp, or a predicate function that will be used to check against the property.
- */
-export function satisfier(expected: Expecter) {
-  function test(actual) {
-    return exec(actual) === null
-  }
-  /**
-   * Check if `actual` satisfies the expected criteria.
-   */
-  function exec(actual: Struct) {
-    if (Array.isArray(actual)) {
-      const diff: SatisfierExec[] = []
-      if (Array.isArray(expected)) {
-        expected.forEach((e, i) => {
-          diff.push(...detectDiff(actual[i], e, [`[${i}]`]))
-        })
-      }
-      else {
-        actual.forEach((a, i) => {
-          diff.push(...detectDiff(a, expected, [`[${i}]`]))
-        })
-      }
-      return diff.length === 0 ? null : diff
-    }
-    const diff = detectDiff(actual, expected)
-    return diff.length === 0 ? null : diff
-  }
-  return {
-    test,
-    exec
-  }
-}
-
-export class Satisfier {
+export class Satisfier<T extends Struct> {
   private satisfier
   /**
    * creates a Satisfier instance
    * @param expected All properties can be a value which will be compared to the same property in `actual`, RegExp, or a predicate function that will be used to check against the property.
    */
-  constructor(expected: Expecter) {
-    this.satisfier = satisfier(expected)
+  constructor(expected: Expecter<T>) {
+    this.satisfier = createSatisfier(expected)
   }
 
   test(actual): boolean {
@@ -59,49 +17,7 @@ export class Satisfier {
   /**
    * Check if `actual` satisfies the expected criteria.
    */
-  exec(actual: Struct): SatisfierExec[] | null {
+  exec(actual: T): SatisfierExec[] | null {
     return this.satisfier.exec(actual)
   }
-}
-
-function detectDiff(actual, expected, path: string[] = []) {
-  const diff: SatisfierExec[] = []
-  const expectedType = typeof expected
-  if (expectedType === 'function') {
-    if (!(expected as Function)(actual)) {
-      diff.push({
-        path,
-        expected: formatFunction(expected as Function),
-        actual
-      })
-    }
-  }
-  else if (expectedType === 'boolean' || expectedType === 'number' || expectedType === 'string' || actual === undefined) {
-    if (expected !== actual)
-      diff.push({
-        path,
-        expected,
-        actual
-      })
-  }
-  else if (expected instanceof RegExp) {
-    if (!expected.test(actual)) {
-      diff.push({
-        path,
-        expected,
-        actual
-      })
-    }
-  }
-  else if (Array.isArray(expected)) {
-    expected.forEach((e, i) => {
-      const actualValue = actual[i]
-      diff.push(...detectDiff(actualValue, e, path.concat([`[${i}]`])))
-    })
-  }
-  else
-    Object.keys(expected).forEach(k => {
-      diff.push(...detectDiff(actual[k], expected[k], path.concat([k])))
-    })
-  return diff
 }

--- a/src/createSatisfier.spec.ts
+++ b/src/createSatisfier.spec.ts
@@ -1,0 +1,8 @@
+import { test } from 'ava'
+import { createSatisfier } from './createSatisfier';
+
+test('support generics', t => {
+  const s = createSatisfier<{ a: number }>({ a: 1 })
+  t.true(s.test({ a: 1 }))
+  t.false(s.test({ a: 2 }))
+})

--- a/src/createSatisfier.spec.ts
+++ b/src/createSatisfier.spec.ts
@@ -1,5 +1,6 @@
 import { test } from 'ava'
-import { createSatisfier } from './createSatisfier';
+
+import { createSatisfier } from './index'
 
 test('support generics', t => {
   const s = createSatisfier<{ a: number }>({ a: 1 })

--- a/src/createSatisfier.ts
+++ b/src/createSatisfier.ts
@@ -1,0 +1,80 @@
+import { formatFunction } from 'function-formatter'
+
+import { Struct, Expecter, SatisfierExec } from './interfaces'
+
+/**
+ * creates a satisfier
+ * @param expected All properties can be a value which will be compared to the same property in `actual`, RegExp, or a predicate function that will be used to check against the property.
+ */
+export function createSatisfier<T extends Struct>(expected: Expecter<T>) {
+  function test(actual: T) {
+    return exec(actual) === null
+  }
+  /**
+   * Check if `actual` satisfies the expected criteria.
+   */
+  function exec(actual: T) {
+    if (Array.isArray(actual)) {
+      const diff: SatisfierExec[] = []
+      if (Array.isArray(expected)) {
+        expected.forEach((e, i) => {
+          diff.push(...detectDiff(actual[i], e, [`[${i}]`]))
+        })
+      }
+      else {
+        actual.forEach((a, i) => {
+          diff.push(...detectDiff(a, expected, [`[${i}]`]))
+        })
+      }
+      return diff.length === 0 ? null : diff
+    }
+    const diff = detectDiff(actual, expected)
+    return diff.length === 0 ? null : diff
+  }
+  return {
+    test,
+    exec
+  }
+}
+
+function detectDiff(actual, expected, path: string[] = []) {
+  const diff: SatisfierExec[] = []
+  const expectedType = typeof expected
+  if (expectedType === 'function') {
+    if (!(expected as Function)(actual)) {
+      diff.push({
+        path,
+        expected: formatFunction(expected as Function),
+        actual
+      })
+    }
+  }
+  else if (expectedType === 'boolean' || expectedType === 'number' || expectedType === 'string' || actual === undefined) {
+    if (expected !== actual)
+      diff.push({
+        path,
+        expected,
+        actual
+      })
+  }
+  else if (expected instanceof RegExp) {
+    if (!expected.test(actual)) {
+      diff.push({
+        path,
+        expected,
+        actual
+      })
+    }
+  }
+  else if (Array.isArray(expected)) {
+    expected.forEach((e, i) => {
+      const actualValue = actual[i]
+      diff.push(...detectDiff(actualValue, e, path.concat([`[${i}]`])))
+    })
+  }
+  else
+    Object.keys(expected).forEach(k => {
+      diff.push(...detectDiff(actual[k], expected[k], path.concat([k])))
+    })
+  return diff
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
+export * from './createSatisfier'
 export * from './interfaces'
 export * from './Satisfier'

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -11,3 +11,9 @@ export type Struct = StructNode | StructHash | (StructNode | StructHash)[]
 export type StructNode = boolean | number | string | object
 
 export type StructHash = { [i: string]: Struct }
+
+export interface SatisfierExec {
+  path: string[],
+  expected: any,
+  actual: any
+}


### PR DESCRIPTION
BREAKING CHANGE: renaming `satisfier()` to `createSatisfier()`.

