### PR TITLE
feat: add `has()` predicate

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,10 @@ createSatisfier({ a: e => typeof e === 'string' })
 
 There are a few predicates shipped in the package for convenience.
 They all support [`tersify`](https://github.com/unional/tersify).
-This means if you use `tersify` to print the predicate (e.g. for logging purpose), you will get a terse string representing the predicates.
+This means if you use `tersify` to print the predicate (e.g. for logging purpose),
+you will get a terse string representing the predicates.
+
+For example:
 
 ```ts
 import { createSatisfier, isInRange } from 'satisfier'

--- a/README.md
+++ b/README.md
@@ -62,24 +62,62 @@ createSatisfier({ a: a => a === 1 }).exec({ a: 2 })
 
 ## test against array
 
-When testing against array, you can use `undefined` to skip over entries that you don't care.
+There are several ways to test against array:
 
-If you want to test against undefined explicitly, use predicate function.
+### using array expectation
+
+When you use an array expectation to test against array,
+each entry in the expectation will be used to test against the corresponding entry in the array.
+
+If the subject array is longer than the expectation array,
+the extra entries are not tested.
+
+You can also skip over entries by putting in `undefined`.
+If you want to test against `undefined` explicitely, use a predicate function.
 
 ```ts
 import { createSatisfier } from 'satisfier'
 
+// all true
+createSatisfier([1]).test([1, 2, 3])
 createSatisfier([undefined, 1]).test(['...anything...', 1])
+createSatisfier([e => e === undefined, 1]).test([undefined, 1])
 ```
 
-When you use a predicate to check against values in an array,
-you will get the index of the array in the second parameter:
+### using predicate expectation
+
+You can test against the array using a predicate function.
+The predicate function will receive the whole array.
+
+This is useful if you want to check the relationship within the array.
 
 ```ts
 import { createSatisfier } from 'satisfier'
 
-createSatisfier((e, i) => i === 0 ? e === '...anything...' : e === 1)
-  .test(['...anything...', 1])
+createSatisfier(
+  a =>
+    Array.isArray(a) &&
+    a.length === 2 &&
+    a[0] === 1 &&
+    a[1] === 2)
+  .test([1, 2])
+```
+
+### using primitive and object expectation
+
+When the expectation is a primitive value or an object,
+it will be used to check against each element in the array.
+
+```ts
+import { createSatisfier } from 'satisfier'
+
+// true
+createSatisfier(1).test([1, 1])
+createSatisfier(false).test([false, false])
+createSatisfier('a').test(['a', 'a'])
+createSatisfier({ a: e => typeof e === 'string' })
+  .test([{ a: 'a' }, { a: 'b' }]))
+
 ```
 
 ## Build in predicates

--- a/package-lock.json
+++ b/package-lock.json
@@ -489,16 +489,6 @@
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
       "dev": true
     },
-    "assertron": {
-      "version": "3.3.10",
-      "resolved": "https://registry.npmjs.org/assertron/-/assertron-3.3.10.tgz",
-      "integrity": "sha512-x0DuWD4weCMlkEMSA1FEPIIcW3xggvzxNGePvJ7xFU77CCiPnpj7FZ/dFUsIb5QUr7w4Vl8Rg4aNg8nXGFL8uA==",
-      "dev": true,
-      "requires": {
-        "satisfier": "3.0.3",
-        "tersify": "1.2.0"
-      }
-    },
     "async-each": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
@@ -7607,15 +7597,6 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
       "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
       "dev": true
-    },
-    "satisfier": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/satisfier/-/satisfier-3.0.3.tgz",
-      "integrity": "sha512-DxqLBwm37uXMMcAEpMSGp7RNbLu6zjgbVqvC/EZQNA9Efmb72+fatMcreEpG6FOObwdRx/kb9qcIiE8msaX5Pw==",
-      "dev": true,
-      "requires": {
-        "tersify": "1.2.0"
-      }
     },
     "semantic-release": {
       "version": "12.2.2",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@types/node": "^8.5.8",
-    "assertron": "^3.3.10",
     "ava": "^0.24.0",
     "dependency-check": "^3.0.0",
     "eslint": "^4.15.0",

--- a/src/createSatisfier.exec.spec.ts
+++ b/src/createSatisfier.exec.spec.ts
@@ -14,7 +14,7 @@ test('can use generic to specify the data structure', t => {
   t.is(createSatisfier<{ a: number }>({ a: /1/ }).exec({ a: 1 }), undefined)
 })
 
-test('empty object expecter passes all objects', t => {
+test('empty object expectation passes all objects', t => {
   t.is(createSatisfier({}).exec({}), undefined)
   t.is(createSatisfier({}).exec({ a: 1 }), undefined)
   t.is(createSatisfier({}).exec({ a: { b: 'a' } }), undefined)
@@ -22,7 +22,7 @@ test('empty object expecter passes all objects', t => {
   t.is(createSatisfier({}).exec({ a: [1] }), undefined)
 })
 
-test('empty object expecter fails primitive', t => {
+test('empty object expectation fails primitive', t => {
   assertExec(t, createSatisfier({}).exec(1)![0], [], {}, 1)
   assertExec(t, createSatisfier({}).exec(true)![0], [], {}, true)
   assertExec(t, createSatisfier({}).exec('a')![0], [], {}, 'a')
@@ -107,7 +107,7 @@ test('when apply against array, will have indices in the path', t => {
   assertExec(t, actual[0], ['[1]', 'a'], 1, undefined)
 })
 
-test('when Expecter is an array, will apply to each entry in the actual array', t => {
+test('when expectation is an array, apply to each entry in the actual array', t => {
   t.is(createSatisfier([{ a: 1 }, { b: 2 }]).exec([{ a: 1 }, { b: 2 }, { c: 3 }]), undefined)
   const actual = createSatisfier([{ a: 1 }, { b: 2 }]).exec([{ a: true }, { b: 'b' }, { c: 3 }])!
   t.is(actual.length, 2)
@@ -115,7 +115,7 @@ test('when Expecter is an array, will apply to each entry in the actual array', 
   assertExec(t, actual[1], ['[1]', 'b'], 2, 'b')
 })
 
-test.skip('when Expecter is an array and actual is not, the behavior is not defined yet', t => {
+test.skip('when expectation is an array and actual is not, the behavior is not defined yet', t => {
   const actual = createSatisfier([{ a: 1 }, { b: 2 }]).exec({ a: 1 })!
   t.is(actual.length, 1)
 })
@@ -152,19 +152,12 @@ test('failing array in hash', t => {
   assertExec(t, actual[0], ['a', '[2]'], 'a', 'b')
 })
 
-test('apply expectation function to each element in array', t => {
-  const satisfier = createSatisfier(e => e.login)
-  t.is(satisfier.exec([{ login: 'a' }]), undefined)
-  t.not(satisfier.exec([{ foo: 'a' }]), undefined)
-})
+test('apply property predicate to array', t => {
+  const satisfier = createSatisfier({
+    data: e => e && e.every(x => x.login)
+  });
 
-test('apply property predicate to each element in array', t => {
-  const satisfier = createSatisfier({ data: e => e && e.login });
-
-  t.is(satisfier.exec({ data: { login: 'a' } }), undefined)
   t.is(satisfier.exec({ data: [{ login: 'a' }] }), undefined)
-  const actual = satisfier.exec({ data: [{ login: 'a' }, {}] })!
-  t.true(createSatisfier({ path: ['data', '[1]'], actual: {} }).test(actual[0]))
-  t.not(satisfier.exec([{ data: { foo: 'a' } }]), undefined)
+  t.not(satisfier.exec([{ data: [{ foo: 'a' }] }]), undefined)
   t.not(satisfier.exec([{ foo: 'b' }]), undefined)
 })

--- a/src/createSatisfier.test.spec.ts
+++ b/src/createSatisfier.test.spec.ts
@@ -61,3 +61,19 @@ test('predicate receives array', t => {
     return e[0] === 'a' && e[1] === 'b'
   }).test(['a', 'b']))
 })
+
+test('primitive predicate will check against element in array', t => {
+  t.true(createSatisfier(1).test([1, 1]))
+  t.false(createSatisfier(1).test([1, 2]))
+  t.true(createSatisfier(false).test([false, false]))
+  t.false(createSatisfier(false).test([false, true]))
+  t.true(createSatisfier('a').test(['a', 'a']))
+  t.false(createSatisfier('a').test(['a', 'b']))
+})
+
+
+test('object predicate will check against element in array', t => {
+  t.true(createSatisfier({ a: 1 }).test([{ a: 1 }, { a: 1 }]))
+  t.true(createSatisfier({ a: e => typeof e === 'string' })
+    .test([{ a: 'a' }, { a: 'b' }]))
+})

--- a/src/createSatisfier.test.spec.ts
+++ b/src/createSatisfier.test.spec.ts
@@ -1,5 +1,4 @@
 import { test } from 'ava'
-import { AssertOrder } from 'assertron'
 
 import { createSatisfier } from './index'
 

--- a/src/createSatisfier.test.spec.ts
+++ b/src/createSatisfier.test.spec.ts
@@ -23,7 +23,6 @@ test('expect null to pass only null', t => {
   t.false(createSatisfier(null).test(''))
 })
 
-
 test('mismatch value fails', t => {
   t.false(createSatisfier({ a: 1 }).test({ a: 2 }))
   t.false(createSatisfier({ a: true }).test({ a: false }))
@@ -45,6 +44,7 @@ test('undefined expectation are ignored', t => {
   t.true(s.test([{ a: 1 }, 1]))
   t.true(s.test([[1, 2], 1]))
 })
+
 test('undefined expectation are ignored', t => {
   const s = createSatisfier({ a: [undefined, 1] })
   t.true(s.test({ a: [undefined, 1] }))
@@ -56,17 +56,8 @@ test('undefined expectation are ignored', t => {
   t.true(s.test({ a: [[1, 2], 1] }))
 })
 
-test('when processing array entry, index will be available to predicate function', t => {
-  const order = new AssertOrder()
-  createSatisfier((e, i) => {
-    const step = order.any([1, 2])
-    if (step === 1) {
-      t.is(e, 'a')
-      t.is(i, 0)
-    }
-    if (step === 2) {
-      t.is(e, 'b')
-      t.is(i, 1)
-    }
-  }).test(['a', 'b'])
+test('predicate receives array', t => {
+  t.true(createSatisfier(e => {
+    return e[0] === 'a' && e[1] === 'b'
+  }).test(['a', 'b']))
 })

--- a/src/createSatisfier.ts
+++ b/src/createSatisfier.ts
@@ -24,6 +24,9 @@ export function createSatisfier<T extends Struct = Struct>(expectation: Expectat
           diff.push(...detectDiff(actual[i], e, [`[${i}]`], i))
         })
       }
+      else if (typeof expectation === 'function') {
+        diff.push(...detectDiff(actual, expectation))
+      }
       else {
         actual.forEach((a, i) => {
           diff.push(...detectDiff(a, expectation, [`[${i}]`], i))
@@ -44,12 +47,13 @@ function detectDiff(actual, expected, path: string[] = [], index?: number) {
   const diff: SatisfierExec[] = []
   const expectedType = typeof expected
   if (expectedType === 'function') {
-    if (Array.isArray(actual)) {
-      actual.forEach((a, i) => {
-        diff.push(...detectDiff(a, expected, path.concat([`[${i}]`]), i))
-      })
-    }
-    else if (!(expected as Function)(actual, index)) {
+    // if (Array.isArray(actual)) {
+    //   actual.forEach((a, i) => {
+    //     diff.push(...detectDiff(a, expected, path.concat([`[${i}]`]), i))
+    //   })
+    // }
+    // else
+    if (!(expected as Function)(actual, index)) {
       diff.push({
         path,
         expected,

--- a/src/createSatisfier.ts
+++ b/src/createSatisfier.ts
@@ -47,12 +47,6 @@ function detectDiff(actual, expected, path: string[] = [], index?: number) {
   const diff: SatisfierExec[] = []
   const expectedType = typeof expected
   if (expectedType === 'function') {
-    // if (Array.isArray(actual)) {
-    //   actual.forEach((a, i) => {
-    //     diff.push(...detectDiff(a, expected, path.concat([`[${i}]`]), i))
-    //   })
-    // }
-    // else
     if (!(expected as Function)(actual, index)) {
       diff.push({
         path,

--- a/src/has.spec.ts
+++ b/src/has.spec.ts
@@ -1,0 +1,29 @@
+import { test } from 'ava'
+
+import { createSatisfier, has } from './index'
+
+test('non array returns false', t => {
+  t.false(createSatisfier(has({ a: 1 })).test(true))
+  t.false(createSatisfier(has({ a: 1 })).test(1))
+  t.false(createSatisfier(has({ a: 1 })).test('{ a: 1 }'))
+  t.false(createSatisfier(has({ a: 1 })).test({ a: 1 }))
+})
+
+test('array with no match returns false', t => {
+  t.false(createSatisfier(has({ a: 1 })).test([{ b: 1 }]))
+})
+
+test('array with one match returns true', t => {
+  t.true(createSatisfier(has({ a: 1 })).test([{ a: 1 }]))
+  t.true(createSatisfier(has({ a: 1 })).test([{ b: 1 }, { a: 1 }]))
+})
+
+
+test('array with more than one match returns true', t => {
+  t.true(createSatisfier(has({ a: 1 })).test([{ a: 1 }, { a: 1 }]))
+  t.true(createSatisfier(has({ a: 1 })).test([{ b: 1 }, { a: 1 }, { a: 1 }, 'x']))
+})
+
+test('tersify()', t => {
+  t.is(has({ a: 1 }).tersify(), 'has({ a: 1 })')
+})

--- a/src/has.ts
+++ b/src/has.ts
@@ -1,0 +1,13 @@
+import {
+  tersible,
+  tersify,
+  // @ts-ignore
+  Tersible
+} from 'tersify'
+
+import { createSatisfier } from './createSatisfier'
+
+export function has(expectation) {
+  const s = createSatisfier(expectation)
+  return tersible(e => e && Array.isArray(e) && e.some(v => s.test(v)), () => `has(${tersify(expectation)})`)
+}

--- a/src/has.ts
+++ b/src/has.ts
@@ -7,6 +7,10 @@ import {
 
 import { createSatisfier } from './createSatisfier'
 
+/**
+ * Check if an array have at least one entry satisfying the expectation.
+ * @param expectation expectation
+ */
 export function has(expectation) {
   const s = createSatisfier(expectation)
   return tersible(e => e && Array.isArray(e) && e.some(v => s.test(v)), () => `has(${tersify(expectation)})`)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export * from './createSatisfier'
+export * from './has'
 export * from './interfaces'
 export * from './isInRange'
 export * from './isInInterval'

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -4,7 +4,7 @@ export type Predicate = (value: any) => boolean
 
 export type TersiblePredicate = Tersible<Predicate>
 
-export type Expectation<T extends Struct = Struct> = Partial<ExpectationHash<T>> | Partial<ExpectationHash<T>>[]
+export type Expectation<T extends Struct = Struct> = Function | Partial<ExpectationHash<T>> | Partial<ExpectationHash<T>>[]
 export type ExpectationNode<T extends Struct = Struct> = undefined | null | boolean | number | string | RegExp | Predicate | Partial<ExpectationHash<T>>
 export type ExpectationHash<T extends Struct = Struct> = {
   [P in keyof T]: ExpectationNode<T[P]> | ExpectationNode<T[P]>[];


### PR DESCRIPTION
BREAKING CHANGE:
remove auto drill in for array.
That actually will create confusion and limit usage.

Without it, you can do compariable within the array as you get the whole array to validate.