### PR TITLE
fix: remove expectation type.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -135,13 +135,30 @@
         }
       }
     },
-    "@semantic-release/commit-analyzer": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-5.0.0.tgz",
-      "integrity": "sha512-DWqE0EwLfqawNzH/cPd987KyplsvwmlKTr6Oz/hPe2NuIwexD8Zt7EvBvHt35udcRsK0EK6+QZTIz06Fr/gIsg==",
+    "@octokit/rest": {
+      "version": "14.0.8",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-14.0.8.tgz",
+      "integrity": "sha512-ccLa2JfROgs4KcsVq4GNFe4W0Il2nwjOVaG1FuFtOKACvlt2Zr6CRgYPrq3ADZXMK/k8yOfNZQYepFmweh9ZrA==",
       "dev": true,
       "requires": {
-        "conventional-changelog-angular": "1.6.0",
+        "before-after-hook": "1.1.0",
+        "debug": "3.1.0",
+        "dotenv": "4.0.0",
+        "https-proxy-agent": "2.1.1",
+        "is-array-buffer": "1.0.0",
+        "is-stream": "1.1.0",
+        "lodash": "4.17.4",
+        "proxy-from-env": "1.0.0",
+        "url-template": "2.0.8"
+      }
+    },
+    "@semantic-release/commit-analyzer": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-5.0.1.tgz",
+      "integrity": "sha512-XrOzS6ymgPmyqRbdtpy6PxgdHdvSb0OWFoajNqNODncKv1jWiAhTu4Mfmx6HzJNBFDM3l57oNu+OY7E5VlPo0w==",
+      "dev": true,
+      "requires": {
+        "conventional-changelog-angular": "1.6.1",
         "conventional-commits-parser": "2.1.0",
         "debug": "3.1.0",
         "import-from": "2.1.0",
@@ -155,21 +172,21 @@
       "dev": true
     },
     "@semantic-release/github": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-3.0.1.tgz",
-      "integrity": "sha512-g1Bw02uc+tICeOw7Dkbu9lTmphf1TFmFyGV28GC6H3rap9cvAPR1ceaUNJLUCHG6C/X0quD+SyZ5drAzaTzTzw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-3.0.3.tgz",
+      "integrity": "sha512-UC7biaDP6Ad64HRgEeZJUNQktlKc/DdToCG1k0rpu3aqWeqsRTctFTyqudXazPVe8boNHBWorEyvuivfYmxf0g==",
       "dev": true,
       "requires": {
+        "@octokit/rest": "14.0.8",
         "@semantic-release/error": "2.1.0",
         "debug": "3.1.0",
         "fs-extra": "5.0.0",
-        "github": "13.1.0",
         "globby": "7.1.1",
         "lodash": "4.17.4",
         "mime": "2.2.0",
         "p-reduce": "1.0.0",
         "parse-github-url": "1.0.2",
-        "url-join": "2.0.5"
+        "url-join": "3.0.0"
       },
       "dependencies": {
         "globby": {
@@ -195,9 +212,9 @@
       }
     },
     "@semantic-release/npm": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-2.6.4.tgz",
-      "integrity": "sha512-bx5smvejFm6O7V4H0Hgr6LXfh6TJ3W5P//IIFaBN+FWvqGNAsyoE0R/LKkZ5KEhLdcT1qRdMv6esdnia7L7zzQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-2.7.0.tgz",
+      "integrity": "sha512-MFfyQXhlityh6xVPVZ1x7P2eELqrP2yH4MsKWROK50X6wCYlZuFf97jmRgxmef5GvfQyt6MDFAVDrHzTry5Cuw==",
       "dev": true,
       "requires": {
         "@semantic-release/error": "2.1.0",
@@ -210,7 +227,7 @@
         "npm-conf": "1.1.3",
         "npm-registry-client": "8.5.0",
         "read-pkg": "3.0.0",
-        "registry-auth-token": "3.3.1"
+        "registry-auth-token": "3.3.2"
       },
       "dependencies": {
         "execa": {
@@ -275,30 +292,36 @@
             "normalize-package-data": "2.4.0",
             "path-type": "3.0.0"
           }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
         }
       }
     },
     "@semantic-release/release-notes-generator": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-6.0.3.tgz",
-      "integrity": "sha512-qvO8B6kUm5cVHdBx0uAla/clAitUR3Pyl+/6a7wSp6RqExgWfa1twq1ekVRBgCHmxX1LFFmLtL3knnSXjpXj1Q==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-6.0.5.tgz",
+      "integrity": "sha512-LxYrkeKU6HD+EBHpArswPW68m76ai3uXlHF0Ol/cC1s6p6im4p/rzXZQ5zYZDBj1CJTaEg0+HnhsfF6JpiGm2Q==",
       "dev": true,
       "requires": {
-        "conventional-changelog-angular": "1.6.0",
-        "conventional-changelog-writer": "2.0.3",
+        "conventional-changelog-angular": "1.6.1",
+        "conventional-changelog-writer": "3.0.0",
         "conventional-commits-parser": "2.1.0",
         "debug": "3.1.0",
         "get-stream": "3.0.0",
-        "git-url-parse": "7.0.2",
+        "git-url-parse": "8.0.1",
         "import-from": "2.1.0",
         "into-stream": "3.1.0",
         "lodash": "4.17.4"
       }
     },
     "@types/node": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.5.8.tgz",
-      "integrity": "sha512-8KmlRxwbKZfjUHFIt3q8TF5S2B+/E5BaAoo/3mgc5h6FJzqxXkCK/VMetO+IRDtwtU6HUvovHMBn+XRj7SV9Qg==",
+      "version": "8.5.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.5.9.tgz",
+      "integrity": "sha512-s+c3AjymyAccTI4hcgNFK4mToH8l+hyPDhu4LIkn71lRy56FLijGu00fyLgldjM/846Pmk9N4KFUs2P8GDs0pA==",
       "dev": true
     },
     "JSONStream": {
@@ -335,12 +358,22 @@
       }
     },
     "agent-base": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.1.2.tgz",
-      "integrity": "sha512-VE6QoEdaugY86BohRtfGmTDabxdU5sCKOkbcPA6PXKJsRzEi/7A3RCTxJal1ft/4qSfPht5/iQLhMh/wzSkkNw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.0.tgz",
+      "integrity": "sha512-c+R/U5X+2zz2+UCrCFv6odQzJdoqI+YecuhnAJLa1zYaMc13zPfwMwZrr91Pd1DYNo/yPRbiM4WVf9whgwFsIg==",
       "dev": true,
       "requires": {
         "es6-promisify": "5.0.0"
+      }
+    },
+    "aggregate-error": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-1.0.0.tgz",
+      "integrity": "sha1-iINE2tAiCnLjr1CQYRf0h3GSX6w=",
+      "dev": true,
+      "requires": {
+        "clean-stack": "1.3.0",
+        "indent-string": "3.2.0"
       }
     },
     "ajv": {
@@ -533,6 +566,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true
+    },
+    "async": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
       "dev": true
     },
     "async-each": {
@@ -762,6 +801,12 @@
           "requires": {
             "ms": "2.0.0"
           }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
         }
       }
     },
@@ -785,6 +830,12 @@
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
           "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         }
       }
@@ -1078,6 +1129,14 @@
           "dev": true,
           "requires": {
             "source-map": "0.5.7"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.5.7",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+              "dev": true
+            }
           }
         }
       }
@@ -1166,6 +1225,12 @@
       "requires": {
         "tweetnacl": "0.14.5"
       }
+    },
+    "before-after-hook": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-1.1.0.tgz",
+      "integrity": "sha512-VOMDtYPwLbIncTxNoSzRyvaMxtXmLWLUqr8k5AfC1BzLk34HvBXaQX8snOwQZ4c0aX8aSERqtJSiI9/m2u5kuA==",
+      "dev": true
     },
     "binary-extensions": {
       "version": "1.11.0",
@@ -1645,7 +1710,7 @@
       "integrity": "sha1-q6CXR9++TD5w52am5BWG4YWfxvI=",
       "dev": true,
       "requires": {
-        "ini": "1.3.4",
+        "ini": "1.3.5",
         "proto-list": "1.2.4"
       }
     },
@@ -1670,9 +1735,9 @@
       "dev": true
     },
     "conventional-changelog-angular": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-1.6.0.tgz",
-      "integrity": "sha1-CiagcfLJ/PzyuGugz79uYwG3W/o=",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-1.6.1.tgz",
+      "integrity": "sha1-4UNNAXyFQDKycvaQQkqMDKFtwxg=",
       "dev": true,
       "requires": {
         "compare-func": "1.3.2",
@@ -1680,9 +1745,9 @@
       }
     },
     "conventional-changelog-writer": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-2.0.3.tgz",
-      "integrity": "sha512-2E1h7UXL0fhRO5h0CxDZ5EBc5sfBZEQePvuZ+gPvApiRrICUyNDy/NQIP+2TBd4wKZQf2Zm7TxbzXHG5HkPIbA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-3.0.0.tgz",
+      "integrity": "sha1-4QYVTtlDQeOH1xe2G+IYH/UyVMw=",
       "dev": true,
       "requires": {
         "compare-func": "1.3.2",
@@ -1757,24 +1822,25 @@
       "dev": true
     },
     "cosmiconfig": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-3.1.0.tgz",
-      "integrity": "sha512-zedsBhLSbPBms+kE7AH4vHg6JsKDz6epSv2/+5XHs8ILHlgDciSJfSWf8sX9aQ52Jb7KI7VswUTsLpR/G0cr2Q==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-4.0.0.tgz",
+      "integrity": "sha512-6e5vDdrXZD+t5v0L8CrurPeybg4Fmf+FCSYxXKYVAqLUtyCSbuyqE059d0kDthTNRzKVjL7QMgNpEUlsoYH3iQ==",
       "dev": true,
       "requires": {
         "is-directory": "0.3.1",
         "js-yaml": "3.10.0",
-        "parse-json": "3.0.0",
+        "parse-json": "4.0.0",
         "require-from-string": "2.0.1"
       },
       "dependencies": {
         "parse-json": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-3.0.0.tgz",
-          "integrity": "sha1-+m9HsY4jgm6tMvJj50TQ4ehH+xM=",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
-            "error-ex": "1.3.1"
+            "error-ex": "1.3.1",
+            "json-parse-better-errors": "1.0.1"
           }
         }
       }
@@ -2099,13 +2165,13 @@
       }
     },
     "env-ci": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/env-ci/-/env-ci-1.2.1.tgz",
-      "integrity": "sha512-xbHk8lh7JO82tqpc72KabaxZ/9a3GxLQwAJgcA55IhnaO7SCv4A1brS23XZQsw7kjDDYINVziuECrExOijkWqA==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/env-ci/-/env-ci-1.3.1.tgz",
+      "integrity": "sha512-W2JSdmuXrrJzTj4HQ3EPxpKiluw0ersnp/RVHWgin3bgYsH6tKOdmUMLRw2KK04pCbUHKd/abnMyD1kMJIDUJw==",
       "dev": true,
       "requires": {
         "execa": "0.9.0",
-        "java-properties": "0.2.9"
+        "java-properties": "0.2.10"
       },
       "dependencies": {
         "execa": {
@@ -2147,9 +2213,9 @@
       "dev": true
     },
     "es6-promise": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.2.tgz",
-      "integrity": "sha512-LSas5vsuA6Q4nEdf9wokY5/AJYXry98i0IzXsv49rYsgDGDNDPbqAYR1Pe23iFxygfbGZNR/5VrHXBCh2BhvUQ==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
+      "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ==",
       "dev": true
     },
     "es6-promisify": {
@@ -2158,7 +2224,7 @@
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "dev": true,
       "requires": {
-        "es6-promise": "4.2.2"
+        "es6-promise": "4.2.4"
       }
     },
     "escape-string-regexp": {
@@ -2168,9 +2234,9 @@
       "dev": true
     },
     "eslint": {
-      "version": "4.15.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.15.0.tgz",
-      "integrity": "sha512-zEO/Z1ZUxIQ+MhDVKkVTUYpIPDTEJLXGMrkID+5v1NeQHtCz6FZikWuFRgxE1Q/RV2V4zVl1u3xmpPADHhMZ6A==",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.16.0.tgz",
+      "integrity": "sha512-YVXV4bDhNoHHcv0qzU4Meof7/P26B4EuaktMi5L1Tnt52Aov85KmYA8c5D+xyZr/BkhvwUqr011jDSD/QTULxg==",
       "dev": true,
       "requires": {
         "ajv": "5.5.2",
@@ -2188,11 +2254,11 @@
         "file-entry-cache": "2.0.0",
         "functional-red-black-tree": "1.0.1",
         "glob": "7.1.2",
-        "globals": "11.1.0",
+        "globals": "11.3.0",
         "ignore": "3.3.7",
         "imurmurhash": "0.1.4",
         "inquirer": "3.3.0",
-        "is-resolvable": "1.0.1",
+        "is-resolvable": "1.1.0",
         "js-yaml": "3.10.0",
         "json-stable-stringify-without-jsonify": "1.0.1",
         "levn": "0.3.0",
@@ -2213,17 +2279,17 @@
       },
       "dependencies": {
         "globals": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-11.1.0.tgz",
-          "integrity": "sha512-uEuWt9mqTlPDwSqi+sHjD4nWU/1N+q0fiWI9T1mZpD2UENqX20CFD5T/ziLZvztPaBKl7ZylUi1q6Qfm7E2CiQ==",
+          "version": "11.3.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.3.0.tgz",
+          "integrity": "sha512-kkpcKNlmQan9Z5ZmgqKH/SMbSmjxQ7QjyNqfXVc8VJcoBV2UEg+sxQD15GQofGRh2hfpwUb70VC31DR7Rq5Hdw==",
           "dev": true
         }
       }
     },
     "eslint-config-unional": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-unional/-/eslint-config-unional-0.3.0.tgz",
-      "integrity": "sha512-bcz1XMqEEXJtGS4AIZn2hG2Z2LLKnov51HWvztfQAIXyQsfwyhGWFxTfryFi24CE8sqmXOKaNe5cKeazNQqx2Q==",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/eslint-config-unional/-/eslint-config-unional-0.3.6.tgz",
+      "integrity": "sha512-P03dqMmjDkv72rjBvQvBF9vzkjUDz1gcCiCbhj5cHJXS7WwJqfemqngjJQZmvB4H7H/I9H7CYA27lBXaZDdZHw==",
       "dev": true
     },
     "eslint-scope": {
@@ -2252,6 +2318,14 @@
         "path-is-absolute": "1.0.1",
         "source-map": "0.5.7",
         "xtend": "4.0.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
       }
     },
     "espree": {
@@ -2449,12 +2523,30 @@
       }
     },
     "find-up": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
       "dev": true,
       "requires": {
-        "locate-path": "2.0.0"
+        "path-exists": "2.1.0",
+        "pinkie-promise": "2.0.1"
+      },
+      "dependencies": {
+        "pinkie": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+          "dev": true
+        },
+        "pinkie-promise": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+          "dev": true,
+          "requires": {
+            "pinkie": "2.0.4"
+          }
+        }
       }
     },
     "flat-cache": {
@@ -3677,27 +3769,12 @@
       }
     },
     "git-url-parse": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-7.0.2.tgz",
-      "integrity": "sha512-OQVonLdJfnGUz7Umyh9NmkZ4j9QmTB+r8ARqqSeZWlMgepn6oTrrHn7wSM5ptJQ1AcXj04xHFacpZVcXvKQAqg==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-8.0.1.tgz",
+      "integrity": "sha512-YmV48kwc6+7PT0/uCMvoNTVfp80Q8qJSKLwBQaCHk2xwEoac5fYElGsWRhN9Dvex1BI7slhwQWia6VbbNUsvWA==",
       "dev": true,
       "requires": {
         "git-up": "2.0.10"
-      }
-    },
-    "github": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/github/-/github-13.1.0.tgz",
-      "integrity": "sha512-xCen2waPsGF4MT9nE4gDwXYSD+ktmDyhQX3l/7cJcfZ0H6hjetkTZh8vzX39q/8sLtRS6iA01Mt5UIGQG9qJng==",
-      "dev": true,
-      "requires": {
-        "debug": "3.1.0",
-        "dotenv": "4.0.0",
-        "https-proxy-agent": "2.1.1",
-        "is-stream": "1.1.0",
-        "lodash": "4.17.4",
-        "proxy-from-env": "1.0.0",
-        "url-template": "2.0.8"
       }
     },
     "glob": {
@@ -3739,7 +3816,7 @@
       "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
       "dev": true,
       "requires": {
-        "ini": "1.3.4"
+        "ini": "1.3.5"
       }
     },
     "globals": {
@@ -3813,23 +3890,6 @@
         "optimist": "0.6.1",
         "source-map": "0.4.4",
         "uglify-js": "2.8.29"
-      },
-      "dependencies": {
-        "async": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.4.4",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-          "dev": true,
-          "requires": {
-            "amdefine": "1.0.1"
-          }
-        }
       }
     },
     "har-schema": {
@@ -3910,6 +3970,12 @@
         "os-tmpdir": "1.0.2"
       }
     },
+    "hook-std": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/hook-std/-/hook-std-0.4.0.tgz",
+      "integrity": "sha1-+osvhNNYdjE3y30X4zCLKHFL0XQ=",
+      "dev": true
+    },
     "hosted-git-info": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
@@ -3933,7 +3999,7 @@
       "integrity": "sha512-LK6tQUR/VOkTI6ygAfWUKKP95I+e6M1h7N3PncGu1CATHCnex+CAv9ttR0lbHu1Uk2PXm/WoAHFo6JCGwMjVMw==",
       "dev": true,
       "requires": {
-        "agent-base": "4.1.2",
+        "agent-base": "4.2.0",
         "debug": "3.1.0"
       }
     },
@@ -3957,6 +4023,14 @@
         "pkg-dir": "2.0.0",
         "resolve-from": "3.0.0",
         "safe-buffer": "5.1.1"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+          "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+          "dev": true
+        }
       }
     },
     "iconv-lite": {
@@ -3984,6 +4058,14 @@
       "dev": true,
       "requires": {
         "resolve-from": "3.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+          "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+          "dev": true
+        }
       }
     },
     "import-lazy": {
@@ -4031,9 +4113,9 @@
       "dev": true
     },
     "ini": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-      "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
       "dev": true
     },
     "inquirer": {
@@ -4081,6 +4163,12 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-1.4.0.tgz",
       "integrity": "sha1-LKmwM2UREYVUEvFr5dd8YqRYp2Y=",
+      "dev": true
+    },
+    "is-array-buffer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-1.0.0.tgz",
+      "integrity": "sha512-KtzJzWuC1kZQ377GJbEsoBh0LuQh1uaZnQg8oL2LcDkY/Ny8rpAzu21Ls3oph3SEKXbnrLHt3rAUVm28iuEPfw==",
       "dev": true
     },
     "is-arrayish": {
@@ -4198,7 +4286,7 @@
       "dev": true,
       "requires": {
         "global-dirs": "0.1.1",
-        "is-path-inside": "1.0.0"
+        "is-path-inside": "1.0.1"
       }
     },
     "is-npm": {
@@ -4243,13 +4331,13 @@
       "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
       "dev": true,
       "requires": {
-        "is-path-inside": "1.0.0"
+        "is-path-inside": "1.0.1"
       }
     },
     "is-path-inside": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
-      "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "dev": true,
       "requires": {
         "path-is-inside": "1.0.2"
@@ -4295,9 +4383,9 @@
       }
     },
     "is-resolvable": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.1.tgz",
-      "integrity": "sha512-y5CXYbzvB3jTnWAZH1Nl7ykUWb6T3BcTs56HUruwBf8MhF56n1HWqhDWnVFo8GHrUPDgvUUNVhrc2U8W7iqz5g==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
+      "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
       "dev": true
     },
     "is-retry-allowed": {
@@ -4391,9 +4479,9 @@
       "dev": true
     },
     "java-properties": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/java-properties/-/java-properties-0.2.9.tgz",
-      "integrity": "sha1-095z5zwwT4RMnior4P8k9vk/2kQ=",
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/java-properties/-/java-properties-0.2.10.tgz",
+      "integrity": "sha512-CpKJh9VRNhS+XqZtg1UMejETGEiqwCGDC/uwPEEQwc2nfdbSm73SIE29TplG2gLYuBOOTNDqxzG6A9NtEPLt0w==",
       "dev": true
     },
     "js-string-escape": {
@@ -4548,6 +4636,14 @@
         "parse-json": "2.2.0",
         "pify": "2.3.0",
         "strip-bom": "3.0.0"
+      },
+      "dependencies": {
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
+        }
       }
     },
     "locate-path": {
@@ -4558,6 +4654,14 @@
       "requires": {
         "p-locate": "2.0.0",
         "path-exists": "3.0.0"
+      },
+      "dependencies": {
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "dev": true
+        }
       }
     },
     "lodash": {
@@ -4786,16 +4890,6 @@
         "trim-newlines": "1.0.0"
       },
       "dependencies": {
-        "find-up": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-          "dev": true,
-          "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
         "load-json-file": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
@@ -4814,15 +4908,6 @@
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
-        },
-        "path-exists": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "dev": true,
-          "requires": {
-            "pinkie-promise": "2.0.1"
-          }
         },
         "path-type": {
           "version": "1.1.0",
@@ -4870,15 +4955,6 @@
             "find-up": "1.1.2",
             "read-pkg": "1.1.0"
           }
-        },
-        "strip-bom": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "dev": true,
-          "requires": {
-            "is-utf8": "0.2.1"
-          }
         }
       }
     },
@@ -4925,9 +5001,9 @@
       }
     },
     "mimic-fn": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
-      "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
       "dev": true
     },
     "minimatch": {
@@ -6789,7 +6865,7 @@
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "dev": true,
       "requires": {
-        "mimic-fn": "1.1.0"
+        "mimic-fn": "1.2.0"
       }
     },
     "optimist": {
@@ -6865,10 +6941,13 @@
       "dev": true
     },
     "p-limit": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
-      "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
-      "dev": true
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
+      "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
+      "dev": true,
+      "requires": {
+        "p-try": "1.0.0"
+      }
     },
     "p-locate": {
       "version": "2.0.0",
@@ -6876,13 +6955,25 @@
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "dev": true,
       "requires": {
-        "p-limit": "1.1.0"
+        "p-limit": "1.2.0"
       }
     },
     "p-reduce": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-1.0.0.tgz",
       "integrity": "sha1-GMKw3ZNqRpClKfgjH1ig/bakffo=",
+      "dev": true
+    },
+    "p-reflect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-reflect/-/p-reflect-1.0.0.tgz",
+      "integrity": "sha1-9Poe4btUbY6z7AMhFI3+CnkTe7g=",
+      "dev": true
+    },
+    "p-try": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
       "dev": true
     },
     "package-hash": {
@@ -6904,7 +6995,7 @@
       "dev": true,
       "requires": {
         "got": "6.7.1",
-        "registry-auth-token": "3.3.1",
+        "registry-auth-token": "3.3.2",
         "registry-url": "3.1.0",
         "semver": "5.4.1"
       }
@@ -6953,10 +7044,30 @@
       }
     },
     "path-exists": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-      "dev": true
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+      "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+      "dev": true,
+      "requires": {
+        "pinkie-promise": "2.0.1"
+      },
+      "dependencies": {
+        "pinkie": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+          "dev": true
+        },
+        "pinkie-promise": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+          "dev": true,
+          "requires": {
+            "pinkie": "2.0.4"
+          }
+        }
+      }
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -7028,6 +7139,15 @@
         "load-json-file": "4.0.0"
       },
       "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "2.0.0"
+          }
+        },
         "load-json-file": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
@@ -7055,6 +7175,12 @@
           "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "dev": true
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
         }
       }
     },
@@ -7065,6 +7191,17 @@
       "dev": true,
       "requires": {
         "find-up": "2.1.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "2.0.0"
+          }
+        }
       }
     },
     "plur": {
@@ -7231,13 +7368,13 @@
       }
     },
     "rc": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.2.tgz",
-      "integrity": "sha1-2M6ctX6NZNnHut2YdsfDTL48cHc=",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.5.tgz",
+      "integrity": "sha1-J1zWh/bjs2zHVrqibf7oCnkDAf0=",
       "dev": true,
       "requires": {
         "deep-extend": "0.4.2",
-        "ini": "1.3.4",
+        "ini": "1.3.5",
         "minimist": "1.2.0",
         "strip-json-comments": "2.0.1"
       },
@@ -7282,6 +7419,17 @@
       "requires": {
         "find-up": "2.1.0",
         "read-pkg": "2.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "2.0.0"
+          }
+        }
       }
     },
     "readable-stream": {
@@ -7382,12 +7530,12 @@
       }
     },
     "registry-auth-token": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.1.tgz",
-      "integrity": "sha1-+w0yie4Nmtosu1KvXf5mywcNMAY=",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
+      "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
       "dev": true,
       "requires": {
-        "rc": "1.2.2",
+        "rc": "1.2.5",
         "safe-buffer": "5.1.1"
       }
     },
@@ -7397,7 +7545,7 @@
       "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
       "dev": true,
       "requires": {
-        "rc": "1.2.2"
+        "rc": "1.2.5"
       }
     },
     "regjsgen": {
@@ -7478,7 +7626,7 @@
         "stringstream": "0.0.5",
         "tough-cookie": "2.3.3",
         "tunnel-agent": "0.6.0",
-        "uuid": "3.1.0"
+        "uuid": "3.2.1"
       }
     },
     "require-from-string": {
@@ -7501,14 +7649,6 @@
       "requires": {
         "caller-path": "0.1.0",
         "resolve-from": "1.0.1"
-      },
-      "dependencies": {
-        "resolve-from": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
-          "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
-          "dev": true
-        }
       }
     },
     "resolve": {
@@ -7527,12 +7667,20 @@
       "dev": true,
       "requires": {
         "resolve-from": "3.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+          "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+          "dev": true
+        }
       }
     },
     "resolve-from": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-      "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+      "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
       "dev": true
     },
     "restore-cursor": {
@@ -7691,28 +7839,31 @@
       "dev": true
     },
     "semantic-release": {
-      "version": "12.2.2",
-      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-12.2.2.tgz",
-      "integrity": "sha512-QAjnKCC0l19SqLX8PlUK/MYVTyieWXj7iozQTZOpML2htF2mUHrjyoSkEj0/Hq1reoQIjOE61IB5905mpUOSkA==",
+      "version": "12.4.1",
+      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-12.4.1.tgz",
+      "integrity": "sha512-Kuc6WzkQHI8sEcqT0cbzwuMBCA1+nhiQGsSnFOYayfqMXSOWJQ1KKg+3W4qemaHUC6EXJInOyUi3fIJb3Ds4Qw==",
       "dev": true,
       "requires": {
-        "@semantic-release/commit-analyzer": "5.0.0",
+        "@semantic-release/commit-analyzer": "5.0.1",
         "@semantic-release/error": "2.1.0",
-        "@semantic-release/github": "3.0.1",
-        "@semantic-release/npm": "2.6.4",
-        "@semantic-release/release-notes-generator": "6.0.3",
+        "@semantic-release/github": "3.0.3",
+        "@semantic-release/npm": "2.7.0",
+        "@semantic-release/release-notes-generator": "6.0.5",
+        "aggregate-error": "1.0.0",
         "chalk": "2.3.0",
         "commander": "2.13.0",
-        "cosmiconfig": "3.1.0",
+        "cosmiconfig": "4.0.0",
         "debug": "3.1.0",
-        "env-ci": "1.2.1",
+        "env-ci": "1.3.1",
         "execa": "0.9.0",
         "get-stream": "3.0.0",
         "git-log-parser": "1.2.0",
+        "hook-std": "0.4.0",
         "lodash": "4.17.4",
         "marked": "0.3.12",
         "marked-terminal": "2.0.0",
         "p-reduce": "1.0.0",
+        "p-reflect": "1.0.0",
         "read-pkg-up": "3.0.0",
         "resolve-from": "4.0.0",
         "semver": "5.4.1"
@@ -7731,6 +7882,15 @@
             "p-finally": "1.0.0",
             "signal-exit": "3.0.2",
             "strip-eof": "1.0.0"
+          }
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "2.0.0"
           }
         },
         "load-json-file": {
@@ -7795,6 +7955,12 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
           "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+          "dev": true
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
           "dev": true
         }
       }
@@ -7894,10 +8060,13 @@
       }
     },
     "source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-      "dev": true
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+      "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+      "dev": true,
+      "requires": {
+        "amdefine": "1.0.1"
+      }
     },
     "source-map-support": {
       "version": "0.5.3",
@@ -8057,10 +8226,13 @@
       }
     },
     "strip-bom": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-      "dev": true
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+      "dev": true,
+      "requires": {
+        "is-utf8": "0.2.1"
+      }
     },
     "strip-bom-buf": {
       "version": "1.0.0",
@@ -8144,9 +8316,9 @@
       }
     },
     "tersify": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/tersify/-/tersify-1.2.0.tgz",
-      "integrity": "sha512-ijGUS0VOIc1SvaWFNME/Fh4c+fTt6cWoC3UjoK0W0wa27SoSVkjM57ztY+i+DYEyj2Aco7rKAGyxT5QGG2QxIw==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tersify/-/tersify-1.2.2.tgz",
+      "integrity": "sha512-8gsDoAXkW742g3CzR4NUDI2xRO3PSTNAuHoLx9TVfCrOgs9/UW1w/Ujt1gO2MuvzrdK99Ywadx2OYOSAHr4rsA==",
       "requires": {
         "unpartial": "0.4.1"
       }
@@ -8382,9 +8554,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.2.tgz",
-      "integrity": "sha1-PFtv1/beCRQmkCfwPAlGdY92c6Q=",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.1.tgz",
+      "integrity": "sha512-bqB1yS6o9TNA9ZC/MJxM0FZzPnZdtHj0xWK/IZ5khzVqdpGul/R/EIiHRgFXlwTD7PSIaYVnGKq1QgMCu2mnqw==",
       "dev": true
     },
     "uglify-js": {
@@ -8397,6 +8569,15 @@
         "source-map": "0.5.7",
         "uglify-to-browserify": "1.0.2",
         "yargs": "3.10.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true,
+          "optional": true
+        }
       }
     },
     "uglify-to-browserify": {
@@ -8476,9 +8657,9 @@
       }
     },
     "url-join": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/url-join/-/url-join-2.0.5.tgz",
-      "integrity": "sha1-WvIvGMBSoACkjXuCxenC4v7tpyg=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-3.0.0.tgz",
+      "integrity": "sha1-JugROs4ZXqMND8OBhuRUAPnOpnI=",
       "dev": true
     },
     "url-parse-lax": {
@@ -8503,9 +8684,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
       "dev": true
     },
     "validate-npm-package-license": {

--- a/package.json
+++ b/package.json
@@ -59,19 +59,19 @@
     "email": "homawong@gmail.com"
   },
   "devDependencies": {
-    "@types/node": "^8.5.8",
+    "@types/node": "^8.5.9",
     "ava": "^0.25.0",
     "dependency-check": "^3.0.0",
-    "eslint": "^4.15.0",
-    "eslint-config-unional": "^0.3.0",
+    "eslint": "^4.16.0",
+    "eslint-config-unional": "^0.3.6",
     "nyc": "^11.4.1",
     "rimraf": "^2.6.2",
-    "semantic-release": "^12.2.2",
+    "semantic-release": "^12.4.1",
     "tslint": "^5.9.1",
     "tslint-config-unional": "^0.9.0",
-    "typescript": "^2.6.2"
+    "typescript": "^2.7.1"
   },
   "dependencies": {
-    "tersify": "^1.2.0"
+    "tersify": "^1.2.2"
   }
 }

--- a/scripts/watch.js
+++ b/scripts/watch.js
@@ -5,15 +5,15 @@ const cp = require('child_process');
 let ava;
 cp.spawn('tsc', ['-w'], { shell: true })
   .stdout.on('data', (data) => {
-    if (!ava) {
-      ava = cp.spawn('ava', ['-w'], {
-        stdio: 'inherit',
-        shell: true
-      })
-    }
     const text = data.toString()
     process.stdout.write(text)
     if (/.*Compilation complete/.test(text)) {
+      if (!ava) {
+        ava = cp.spawn('ava', ['-w'], {
+          stdio: 'inherit',
+          shell: true
+        })
+      }
       let lint = cp.spawnSync('npm', ['run', 'lint'], {
         stdio: 'inherit',
         shell: true

--- a/src/createSatisfier.ts
+++ b/src/createSatisfier.ts
@@ -1,10 +1,10 @@
-import { Struct, Expectation, SatisfierExec } from './interfaces'
+import { SatisfierExec } from './interfaces'
 
 /**
  * creates a satisfier
  * @param expectation All properties can be a value which will be compared to the same property in `actual`, RegExp, or a predicate function that will be used to check against the property.
  */
-export function createSatisfier<T extends Struct = Struct>(expectation: Expectation<T>): {
+export function createSatisfier<T = any>(expectation: any): {
   test: (actual: T) => boolean;
   exec: (actual: T) => SatisfierExec[] | undefined;
 } {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -4,20 +4,8 @@ export type Predicate = (value: any) => boolean
 
 export type TersiblePredicate = Tersible<Predicate>
 
-export type Expectation<T extends Struct = Struct> = Function | Partial<ExpectationHash<T>> | Partial<ExpectationHash<T>>[]
-export type ExpectationNode<T extends Struct = Struct> = undefined | null | boolean | number | string | RegExp | Predicate | Partial<ExpectationHash<T>>
-export type ExpectationHash<T extends Struct = Struct> = {
-  [P in keyof T]: ExpectationNode<T[P]> | ExpectationNode<T[P]>[];
-}
-
-export type Struct = null | StructNode | StructHash | (StructNode | StructHash)[]
-
-export type StructNode = boolean | number | string | object
-
-export type StructHash = { [i: string]: Struct }
-
 export interface SatisfierExec {
   path: string[],
-  expected: boolean | number | string | RegExp | Predicate | ExpectationHash,
+  expected: any,
   actual: any
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "esModuleInterop": true,
     "lib": [
       "dom",
       "es2015"


### PR DESCRIPTION
TypeScript 2.7 is getting smarter and the Expectation type becomes too complicate to create.

Remove the type and use any instead.

If there is a way to add it back, make that an enhancement.