### PR TITLE
ci: publish through OIDC and point both jobs at cyberuni

### DIFF
--- a/.changeset/olive-jars-attend.md
+++ b/.changeset/olive-jars-attend.md
@@ -1,0 +1,8 @@
+---
+'satisfier': patch
+---
+
+Publish through npm trusted publishing (OIDC) with provenance, and correct the package
+`version` back to the last real release. The previous `0.0.0-development` placeholder was
+taken literally by changesets and published as `latest` on 2026-08-09; this release moves
+the `latest` dist-tag back onto a real version.

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -2,9 +2,17 @@ name: pull-request
 on:
   pull_request:
     types: [opened, synchronize]
+  merge_group:
 
 jobs:
   code:
-    uses: unional/.github/.github/workflows/pnpm-verify.yml@main
+    uses: cyberuni/.github/.github/workflows/pnpm-verify.yml@main
     with:
       os: '["ubuntu-latest"]'
+      skip-playwright: true
+
+  publish-gate:
+    if: startsWith(github.head_ref, 'changeset-release/')
+    uses: cyberuni/.github/.github/workflows/pnpm-publish-gate.yml@main
+    permissions:
+      contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,11 +5,15 @@ on:
 
 jobs:
   code:
-    uses: unional/.github/.github/workflows/pnpm-verify.yml@main
+    uses: cyberuni/.github/.github/workflows/pnpm-verify.yml@main
     with:
       os: '["ubuntu-latest"]'
+      skip-playwright: true
 
   release:
-    uses: unional/.github/.github/workflows/pnpm-release-changeset.yml@main
+    uses: cyberuni/.github/.github/workflows/pnpm-release-changeset-oidc.yml@main
     needs: code
-    secrets: inherit
+    permissions:
+      id-token: write
+      contents: write
+      pull-requests: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# satisfier
+
 ## [5.4.2](https://github.com/unional/satisfier/compare/v5.4.1...v5.4.2) (2022-10-08)
 
 

--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 [![NPM version][npm-image]][npm-url]
 [![NPM downloads][downloads-image]][downloads-url]
 
-[![GitHub NodeJS][github-nodejs]][github-action-url]
+[![GitHub Actions][github-actions-image]][github-action-url]
 [![Codecov][codecov-image]][codecov-url]
 
-[![Semantic Release][semantic-release-image]][semantic-release-url]
+[![Changesets][changesets-image]][changesets-url]
 
 [![Visual Studio Code][vscode-image]][vscode-url]
 
@@ -187,15 +187,15 @@ git push
 # create PR
 ```
 
-[codecov-image]: https://codecov.io/gh/unional/satisfier/branch/master/graph/badge.svg
-[codecov-url]: https://codecov.io/gh/unional/satisfier
+[changesets-image]: https://img.shields.io/badge/%F0%9F%A6%8B-changesets-blue.svg
+[changesets-url]: https://github.com/changesets/changesets
+[codecov-image]: https://codecov.io/gh/cyberuni/satisfier/branch/main/graph/badge.svg
+[codecov-url]: https://codecov.io/gh/cyberuni/satisfier
 [downloads-image]: https://img.shields.io/npm/dm/satisfier.svg?style=flat
 [downloads-url]: https://npmjs.org/package/satisfier
-[github-action-url]: https://github.com/unional/satisfier/actions
-[github-nodejs]: https://github.com/unional/satisfier/workflows/nodejs/badge.svg
+[github-action-url]: https://github.com/cyberuni/satisfier/actions
+[github-actions-image]: https://github.com/cyberuni/satisfier/actions/workflows/release.yml/badge.svg
 [npm-image]: https://img.shields.io/npm/v/satisfier.svg?style=flat
 [npm-url]: https://npmjs.org/package/satisfier
-[semantic-release-image]: https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg
-[semantic-release-url]: https://github.com/semantic-release/semantic-release
 [vscode-image]: https://img.shields.io/badge/vscode-ready-green.svg
 [vscode-url]: https://code.visualstudio.com/

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
 	"name": "satisfier",
-	"version": "0.0.0-development",
+	"version": "5.4.2",
 	"description": "A purposely loose comparison tool.",
-	"homepage": "https://github.com/unional/satisfier",
+	"homepage": "https://github.com/cyberuni/satisfier",
 	"bugs": {
-		"url": "https://github.com/unional/satisfier/issues"
+		"url": "https://github.com/cyberuni/satisfier/issues"
 	},
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/unional/satisfier.git"
+		"url": "https://github.com/cyberuni/satisfier.git"
 	},
 	"license": "MIT",
 	"author": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
   ],
   "typedocOptions": {
     "customTitle": "A purposely loose comparison tool.",
-    "customTitleLink": "https://github.com/unional/satisfier",
+    "customTitleLink": "https://github.com/cyberuni/satisfier",
     "entryPoints": [
       "ts/index.ts"
     ],


### PR DESCRIPTION
Phase A of the repo-modernization sweep. **Do not merge yet** — this PR is written against the world *after* the repo is transferred to `cyberuni` and `satisfier` is registered for npm trusted publishing. Landing it before that breaks the release.

## Pre-existing state, before anything here was touched

- **`package.json` `version` was `0.0.0-development`** — a leftover semantic-release placeholder. The release run on `main` at 2026-08-09T17:52 (run 31327564833) went green and changesets took it literally: **`satisfier@0.0.0-development` is now published and holds the `latest` dist-tag on npm**, over the real `5.4.2` from 2022. `npm i satisfier` currently serves a stub. This is the same trap `fsa-emitter` hit in batch 1.
- The five release runs before that one had been failing on `E404 undefined` at publish since at least 2026-07-23.
- **Main-branch CI was already green.** The red PR runs are all Renovate *major* upgrade branches (jest v30, typescript v7, eslint v10, husky v9) failing on their own upgrades — e.g. husky 9 removes `husky install`, so `depcheck` reports husky unused and exits 255. Those are toolchain work, out of scope here, and untouched.
- No repo ruleset existed; `main` was on legacy branch protection.

## What changed

**Workflows**
- `release.yml`: `cyberuni/.github/.github/workflows/pnpm-release-changeset-oidc.yml@main` with an explicit `permissions:` block (`id-token` / `contents` / `pull-requests`); `secrets: inherit` dropped.
- `pull-request.yml` + `release.yml` `code` job: `cyberuni/.github/.github/workflows/pnpm-verify.yml@main`, `os: '["ubuntu-latest"]'`, `skip-playwright: true`. Codecov upload left on (it defaults on and feeds the README badge).
- `pull-request.yml` gains `merge_group:` and the changesets `publish-gate` job.
- `grep -rn "unional/.github" .github/workflows/` now returns nothing.

**Metadata**
- `version`: `0.0.0-development` → `5.4.2`.
- `repository` / `homepage` / `bugs`, README badges, and the typedoc `customTitleLink` → `cyberuni/satisfier`. The **npm package name is unchanged** — it is unscoped `satisfier` and stays that way.
- README: dead `nodejs` workflow badge → the `release.yml` badge; semantic-release badge → changesets; codecov badge branch `master` → `main`.
- `CHANGELOG.md` gains a `# satisfier` H1 so changesets inserts entries in the right place.

**Changeset** — a deliberate `patch`, so the first release after the transfer actually publishes and moves `latest` off the `0.0.0-development` stub.

**Repo settings** (applied directly, not in this diff): baseline `main` ruleset requiring `code / all-checks` and nothing else, created *before* the legacy branch protection was removed; merge-commit shape (`allow_merge_commit`, no squash/rebase, `allow_update_branch`); secret scanning + push protection enabled.

## Deliberately not done

- Not merged, no auto-merge armed. The repo has **not** been transferred and no `npm trust` command was run — both are Phase B.
- `NPM_TOKEN` / `CI_GITHUB_TOKEN` left in place until an OIDC publish has proven itself.
- `default_workflow_permissions` left at `write` — the `permissions:` block that would let it drop to `read` is in this unmerged PR.
- Renovate major-upgrade breakage, the leftover `.yarn/` + `.yarnrc.yml`, and the eslint→biome swap are toolchain scope, not Phase A.

## Owner follow-up needing an OTP

`satisfier@0.0.0-development` should be **deprecated** on the registry. Publishing `5.4.3` from this branch moves `latest` back to a real version, but the stub stays installable by exact version until deprecated.